### PR TITLE
Add Node 14, CJS, and TypeScript support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 coverage/
+dist/
 .DS_Store
 *.log
 *~

--- a/package.json
+++ b/package.json
@@ -3,16 +3,74 @@
     "version": "1.0.3",
     "description": "IP address encryption and obfuscation",
     "type": "module",
-    "main": "index.js",
+    "main": "./dist/index.cjs",
+    "module": "./dist/index.js",
+    "types": "./dist/index.d.ts",
     "exports": {
-        ".": "./index.js",
-        "./deterministic": "./src/ipcrypt-deterministic.js",
-        "./nd": "./src/ipcrypt-nd.js",
-        "./ndx": "./src/ipcrypt-ndx.js",
-        "./pfx": "./src/ipcrypt-pfx.js",
-        "./utils": "./src/utils.js"
+        ".": {
+            "import": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            },
+            "require": {
+                "types": "./dist/index.d.cts",
+                "default": "./dist/index.cjs"
+            }
+        },
+        "./deterministic": {
+            "import": {
+                "types": "./dist/ipcrypt-deterministic.d.ts",
+                "default": "./dist/ipcrypt-deterministic.js"
+            },
+            "require": {
+                "types": "./dist/ipcrypt-deterministic.d.cts",
+                "default": "./dist/ipcrypt-deterministic.cjs"
+            }
+        },
+        "./nd": {
+            "import": {
+                "types": "./dist/ipcrypt-nd.d.ts",
+                "default": "./dist/ipcrypt-nd.js"
+            },
+            "require": {
+                "types": "./dist/ipcrypt-nd.d.cts",
+                "default": "./dist/ipcrypt-nd.cjs"
+            }
+        },
+        "./ndx": {
+            "import": {
+                "types": "./dist/ipcrypt-ndx.d.ts",
+                "default": "./dist/ipcrypt-ndx.js"
+            },
+            "require": {
+                "types": "./dist/ipcrypt-ndx.d.cts",
+                "default": "./dist/ipcrypt-ndx.cjs"
+            }
+        },
+        "./pfx": {
+            "import": {
+                "types": "./dist/ipcrypt-pfx.d.ts",
+                "default": "./dist/ipcrypt-pfx.js"
+            },
+            "require": {
+                "types": "./dist/ipcrypt-pfx.d.cts",
+                "default": "./dist/ipcrypt-pfx.cjs"
+            }
+        },
+        "./utils": {
+            "import": {
+                "types": "./dist/utils.d.ts",
+                "default": "./dist/utils.js"
+            },
+            "require": {
+                "types": "./dist/utils.d.cts",
+                "default": "./dist/utils.cjs"
+            }
+        }
     },
     "scripts": {
+        "build": "tsup",
+        "prepublishOnly": "npm run build",
         "test": "bun test/test.js",
         "test:ip": "bun test/test-ip.js",
         "test:pfx": "bun test/test-pfx.js",
@@ -27,12 +85,13 @@
         "security",
         "ipv4",
         "ipv6",
-        "obfuscation"
+        "obfuscation",
+        "typescript"
     ],
     "author": "Frank Denis",
     "license": "ISC",
     "engines": {
-        "node": ">=16.0.0",
+        "node": ">=14.0.0",
         "bun": ">=1.0.0"
     },
     "repository": {
@@ -43,12 +102,15 @@
         "url": "https://github.com/jedisct1/ipcrypt-js/issues"
     },
     "files": [
-        "src",
-        "index.js",
+        "dist",
         "README.md",
         "LICENSE"
     ],
+    "sideEffects": false,
     "devDependencies": {
-        "eslint": "^8.57.1"
+        "@types/node": "^24.9.1",
+        "eslint": "^8.57.1",
+        "tsup": "^8.5.0",
+        "typescript": "^5.9.3"
     }
 }

--- a/src/ipcrypt-nd.js
+++ b/src/ipcrypt-nd.js
@@ -1,4 +1,4 @@
-import { ipToBytes, bytesToIp } from './utils.js';
+import { ipToBytes, bytesToIp, randomBytes } from './utils.js';
 import { encrypt as encryptBlock, decrypt as decryptBlock } from './core/kiasu-bc.js';
 
 /**
@@ -23,8 +23,7 @@ export function encrypt(ip, key, tweak) {
 
     // Generate random tweak if not provided
     if (!tweak) {
-        tweak = new Uint8Array(8);
-        crypto.getRandomValues(tweak);
+        tweak = randomBytes(8);
     } else if (!(tweak instanceof Uint8Array) || tweak.length !== 8) {
         throw new Error('Tweak must be an 8-byte Uint8Array');
     }

--- a/src/ipcrypt-ndx.js
+++ b/src/ipcrypt-ndx.js
@@ -1,5 +1,5 @@
 import { subBytes, shiftRows, mixColumns, expandKey } from './core/aes.js';
-import { ipToBytes, bytesToIp } from './utils.js';
+import { ipToBytes, bytesToIp, randomBytes } from './utils.js';
 
 /**
  * Encrypt a single block using AES-XTS mode (XEX Tweakable Block Cipher with Ciphertext Stealing).
@@ -216,8 +216,7 @@ export function encrypt(ip, key, tweak = null) {
 
     // Generate random tweak if not provided
     if (!tweak) {
-        tweak = new Uint8Array(16);
-        crypto.getRandomValues(tweak);
+        tweak = randomBytes(16);
     } else if (!(tweak instanceof Uint8Array) || tweak.length !== 16) {
         throw new Error('Tweak must be a 16-byte Uint8Array');
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -140,14 +140,24 @@ export function bytesToIp(bytes) {
 }
 
 /**
- * Generate cryptographically secure random bytes using Web Crypto API.
- * 
+ * Generate cryptographically secure random bytes.
+ * Uses Web Crypto API (Node 15+) with fallback to crypto.randomFillSync (Node 14+).
+ *
  * @param {number} length - Number of bytes to generate
  * @returns {Uint8Array} Random bytes
  */
 export function randomBytes(length) {
     const bytes = new Uint8Array(length);
-    crypto.getRandomValues(bytes);
+
+    // Feature detection: Use getRandomValues if available (Node 15+),
+    // otherwise fall back to randomFillSync (Node 14+)
+    if (crypto.getRandomValues) {
+        crypto.getRandomValues(bytes);
+    } else {
+        // Node 14 compatibility: use randomFillSync instead
+        crypto.randomFillSync(bytes);
+    }
+
     return bytes;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020"],
+    "moduleResolution": "node",
+    "allowJs": true,
+    "checkJs": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": [
+    "index.js",
+    "src/**/*.js"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "test"
+  ]
+}

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -1,0 +1,22 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    'index': 'index.js',
+    'ipcrypt-deterministic': 'src/ipcrypt-deterministic.js',
+    'ipcrypt-nd': 'src/ipcrypt-nd.js',
+    'ipcrypt-ndx': 'src/ipcrypt-ndx.js',
+    'ipcrypt-pfx': 'src/ipcrypt-pfx.js',
+    'utils': 'src/utils.js',
+  },
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  treeshake: true,
+  minify: false,
+  outDir: 'dist',
+  external: ['crypto'],
+  skipNodeModulesBundle: true,
+});


### PR DESCRIPTION
Extend support for Node 14+, CommonJS (CJS), and TypeScript type definitions.

Key changes:
- Node 14 compatibility via crypto.randomFillSync fallback
- Dual CJS/ESM package support with tsup
- TypeScript type definitions from JSDoc
- Proper conditional exports configuration
- All tests passing + type info validated with @arethetypeswrong/cli